### PR TITLE
Removes deprecation warning by using pipelined block form

### DIFF
--- a/lib/lita/room.rb
+++ b/lib/lita/room.rb
@@ -96,9 +96,9 @@ module Lita
     def save
       ensure_name_metadata_set
 
-      redis.pipelined do
-        redis.hmset("id:#{id}", *metadata.to_a.flatten)
-        redis.set("name:#{name}", id)
+      redis.pipelined do |pipeline|
+        pipeline.hmset("id:#{id}", *metadata.to_a.flatten)
+        pipeline.set("name:#{name}", id)
       end
     end
 

--- a/lib/lita/user.rb
+++ b/lib/lita/user.rb
@@ -116,11 +116,11 @@ module Lita
       redis_keys = redis.hkeys("id:#{id}")
       delete_keys = (redis_keys - current_keys)
 
-      redis.pipelined do
-        redis.hdel("id:#{id}", *delete_keys) if delete_keys.any?
-        redis.hmset("id:#{id}", *metadata.to_a.flatten)
-        redis.set("name:#{name}", id)
-        redis.set("mention_name:#{mention_name}", id) if mention_name
+      redis.pipelined do |pipeline|
+        pipeline.hdel("id:#{id}", *delete_keys) if delete_keys.any?
+        pipeline.hmset("id:#{id}", *metadata.to_a.flatten)
+        pipeline.set("name:#{name}", id)
+        pipeline.set("mention_name:#{mention_name}", id) if mention_name
       end
     end
 


### PR DESCRIPTION
This removes a deprecation warning regarding the form of the `pipelined` command without a block.