### PR TITLE
v5.0.1

### DIFF
--- a/lib/lita/version.rb
+++ b/lib/lita/version.rb
@@ -2,5 +2,5 @@
 
 module Lita
   # The current version of Lita.
-  VERSION = "5.0.0"
+  VERSION = "5.0.1"
 end


### PR DESCRIPTION
* Removes Redis deprecation warning by using pipelined block form
* Puma 6 support
* Removed bundler as a direct dependency
* Bug Fix: The Redis response from `sadd` and `srem` can also be a `Fixnum`